### PR TITLE
Validate that the proposer payment has no calldata and its gas price

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2490,5 +2490,21 @@ func (bc *BlockChain) ValidatePayload(block *types.Block, feeRecipient common.Ad
 		return fmt.Errorf("inaccurate payment %s, expected %s", paymentTx.Value().String(), expectedProfit.String())
 	}
 
+	if len(paymentTx.Data()) != 0 {
+		return fmt.Errorf("malformed proposer payment, contains calldata")
+	}
+
+	if paymentTx.GasPrice().Cmp(block.BaseFee()) != 0 {
+		return fmt.Errorf("malformed proposer payment, gas price not equal to base fee")
+	}
+
+	if paymentTx.GasTipCap().Cmp(block.BaseFee()) != 0 && paymentTx.GasTipCap().Sign() != 0 {
+		return fmt.Errorf("malformed proposer payment, unexpected gas tip cap")
+	}
+
+	if paymentTx.GasFeeCap().Cmp(block.BaseFee()) != 0 {
+		return fmt.Errorf("malformed proposer payment, unexpected gas fee cap")
+	}
+
 	return nil
 }


### PR DESCRIPTION
Validation will ensure the proposer payment is a transfer and not an arbitrary contract call, and that the gas price is exactly the base fee. The later check is there to make finding a pending transfer that would be mistaken for a proposer payment more unlikely.
It was suggested to validate that the payment is coming from coinbase, but that is actually not sufficient, as the blocks coinbase could be set to "from" the pending payment if the payment is high enough, and would still allow for stealing the block space.