### PR TITLE
Pass validation-specific config

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -188,7 +188,12 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	// Configure log filter RPC API.
 	filterSystem := utils.RegisterFilterAPI(stack, backend, &cfg.Eth)
 
-	if err := blockvalidationapi.Register(stack, eth, ctx); err != nil {
+	bvConfig := blockvalidationapi.BlockValidationConfig{}
+	if ctx.IsSet(utils.BuilderBlockValidationBlacklistSourceFilePath.Name) {
+		bvConfig.BlacklistSourceFilePath = ctx.String(utils.BuilderBlockValidationBlacklistSourceFilePath.Name)
+	}
+
+	if err := blockvalidationapi.Register(stack, eth, bvConfig); err != nil {
 		utils.Fatalf("Failed to register the Block Validation API: %v", err)
 	}
 

--- a/eth/block-validation/api.go
+++ b/eth/block-validation/api.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 	"os"
 
-	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/beacon"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -17,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/urfave/cli/v2"
 
 	boostTypes "github.com/flashbots/go-boost-utils/types"
 )
@@ -87,12 +85,16 @@ func NewAccessVerifierFromFile(path string) (*AccessVerifier, error) {
 	}, nil
 }
 
+type BlockValidationConfig struct {
+	BlacklistSourceFilePath string
+}
+
 // Register adds catalyst APIs to the full node.
-func Register(stack *node.Node, backend *eth.Ethereum, ctx *cli.Context) error {
+func Register(stack *node.Node, backend *eth.Ethereum, cfg BlockValidationConfig) error {
 	var accessVerifier *AccessVerifier
-	if ctx.IsSet(utils.BuilderBlockValidationBlacklistSourceFilePath.Name) {
+	if cfg.BlacklistSourceFilePath != "" {
 		var err error
-		accessVerifier, err = NewAccessVerifierFromFile(ctx.String(utils.BuilderBlockValidationBlacklistSourceFilePath.Name))
+		accessVerifier, err = NewAccessVerifierFromFile(cfg.BlacklistSourceFilePath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Internals shouldn't import `github.com/ethereum/go-ethereum/cmd/utils` as it causes import cycles