### PR TITLE
Minor error handling improvment for ValidatePayload

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2461,7 +2461,9 @@ func (bc *BlockChain) ValidatePayload(block *types.Block, feeRecipient common.Ad
 		return err
 	}
 
-	if err := bc.validator.ValidateBody(block); err != nil {
+	// Check if the body is valid. Ignore ErrKnownBlock because known blocks are
+	// by definition valid.
+	if err := bc.validator.ValidateBody(block); err != nil && err != ErrKnownBlock {
 		return err
 	}
 


### PR DESCRIPTION
In `ValidatePayload`, we call `bc.validator.ValidateBody` which is defined [here](https://github.com/flashbots/block-validation-geth/blob/edb750b94d886d70698c3b20a2248046f8b941b5/core/block_validator.go#L53). That function returns an error `ErrKnownBlock` if the block that we are validating is already part of the canonical chain. By definition, this implies that the block is valid, and thus it feels cleaner to ignore this error.